### PR TITLE
Add Tailscale ipv4/ipv6 to DeviceInfo schema

### DIFF
--- a/2.4.0/printnanny-os.yml
+++ b/2.4.0/printnanny-os.yml
@@ -245,6 +245,12 @@ components:
           printnanny_cli_version:
             type: string
             description: "Output of printnanny --version"
+          tailscale_address_ipv4:
+            type: string
+            description: "tailscale ip -4"
+          tailscale_address_ipv6:
+            type: string
+            description: "tailscale ip -6"
         required:
           - issue
           - os_release

--- a/clients/rust/src/device_info_load_reply.rs
+++ b/clients/rust/src/device_info_load_reply.rs
@@ -7,14 +7,20 @@ pub struct DeviceInfoLoadReply {
     pub os_release: String,
     #[serde(rename="printnanny_cli_version")]
     pub printnanny_cli_version: String,
+    #[serde(rename="tailscale_address_ipv4", skip_serializing_if = "Option::is_none")]
+    pub tailscale_address_ipv4: Option<String>,
+    #[serde(rename="tailscale_address_ipv6", skip_serializing_if = "Option::is_none")]
+    pub tailscale_address_ipv6: Option<String>,
 }
 
 impl DeviceInfoLoadReply {
-    pub fn new(issue: String, os_release: String, printnanny_cli_version: String) -> DeviceInfoLoadReply {
+    pub fn new(issue: String, os_release: String, printnanny_cli_version: String, tailscale_address_ipv4: Option<String>, tailscale_address_ipv6: Option<String>) -> DeviceInfoLoadReply {
         DeviceInfoLoadReply {
             issue,
             os_release,
             printnanny_cli_version,
+            tailscale_address_ipv4,
+            tailscale_address_ipv6,
         }
     }
 }

--- a/clients/typescript/src/DeviceInfoLoadReply.ts
+++ b/clients/typescript/src/DeviceInfoLoadReply.ts
@@ -3,4 +3,6 @@ export interface DeviceInfoLoadReply {
   issue: string;
   os_release: string;
   printnanny_cli_version: string;
+  tailscale_address_ipv4?: string;
+  tailscale_address_ipv6?: string;
 }


### PR DESCRIPTION
ref: https://github.com/bitsy-ai/printnanny-os/issues/155
