### PR TITLE
Rename name -> display_name

### DIFF
--- a/2.4.0/printnanny-os.yml
+++ b/2.4.0/printnanny-os.yml
@@ -893,7 +893,7 @@ components:
       properties:
         cover:
           type: string
-        name:
+        display_name:
           type: string
         uri:
           type: string
@@ -901,7 +901,7 @@ components:
           $ref: "#/components/schemas/PlaybackSourceType"
       required:
         - cover
-        - name
+        - display_name
         - uri
         - src_type
 

--- a/clients/rust/src/playback_video.rs
+++ b/clients/rust/src/playback_video.rs
@@ -3,8 +3,8 @@
 pub struct PlaybackVideo {
     #[serde(rename="cover")]
     pub cover: String,
-    #[serde(rename="name")]
-    pub name: String,
+    #[serde(rename="display_name")]
+    pub display_name: String,
     #[serde(rename="uri")]
     pub uri: String,
     #[serde(rename="src_type")]
@@ -12,10 +12,10 @@ pub struct PlaybackVideo {
 }
 
 impl PlaybackVideo {
-    pub fn new(cover: String, name: String, uri: String, src_type: crate::PlaybackSourceType) -> PlaybackVideo {
+    pub fn new(cover: String, display_name: String, uri: String, src_type: crate::PlaybackSourceType) -> PlaybackVideo {
         PlaybackVideo {
             cover,
-            name,
+            display_name,
             uri,
             src_type: Box::new(src_type),
         }

--- a/clients/typescript/src/PlaybackVideo.ts
+++ b/clients/typescript/src/PlaybackVideo.ts
@@ -1,7 +1,7 @@
 import {PlaybackSourceType} from './PlaybackSourceType';
 export interface PlaybackVideo {
   cover: string;
-  reserved_name: string;
+  display_name: string;
   uri: string;
   src_type: PlaybackSourceType;
 }


### PR DESCRIPTION
Rename field `name` until https://github.com/asyncapi/modelina/issues/1053 is resolved. 

Because `name` is converted into `reserved_name` in the Typescript models, we can't serialize data in Typescript and deserialize in Rust and vice-versa.