### PR TITLE
Implement: WebrtcRecordingFileName Request/Response schemas

### DIFF
--- a/2.4.0/printnanny-os.yml
+++ b/2.4.0/printnanny-os.yml
@@ -284,6 +284,19 @@ channels:
       message:
         $ref: "#/components/messages/SettingsFileRevertRequest"
 
+  pi.{pi_id}.webrtc.recording.file_name:
+    parameters:
+      pi_id:
+        $ref: "#/components/parameters/pi_id"
+    publish:
+      operationId: WebrtcRecordingFileNameRequest
+      message:
+        $ref: "#/components/messages/WebrtcRecordingFileNameRequest"
+    subscribe:
+      operationId: WebrtcRecordingFileNameResponse
+      message:
+        $ref: "#/components/messages/WebrtcRecordingFileNameResponse"
+
   pi.{pi_id}.webrtc.recording.started:
     parameters:
       pi_id:
@@ -322,18 +335,6 @@ components:
               $ref: "#/components/schemas/Camera"
         required:
           - cameras
-
-    WebrtcRecordingStarted:
-      name: WebrtcRecordingStarted
-      summary: "Janus WebRTC gateway has started saving RTP packets to .mjr"
-      payload:
-        $ref: "#/components/schemas/WebrtcRecording"
-
-    WebrtcRecordingStopped:
-      name: WebrtcRecordingStopped
-      summary: "Janus WebRTC gateway has stopped saving RTP packets to .mjr"
-      payload:
-        $ref: "#/components/schemas/WebrtcRecording"
 
     CameraSettingsFileApplyRequest:
       name: CameraSettingsFileApplyRequest
@@ -933,12 +934,44 @@ components:
           - subject_pattern
           - request
 
+    WebrtcRecordingStarted:
+      name: WebrtcRecordingStarted
+      summary: "Janus WebRTC gateway has started saving RTP packets to .mjr"
+      payload:
+        $ref: "#/components/schemas/WebrtcRecording"
+
+    WebrtcRecordingStopped:
+      name: WebrtcRecordingStopped
+      summary: "Janus WebRTC gateway has stopped saving RTP packets to .mjr"
+      payload:
+        $ref: "#/components/schemas/WebrtcRecording"
+
+    WebrtcRecordingFileNameRequest:
+      name: WebrtcRecordingFileNameRequest
+      summary: "Attempt to get file name of active print job. If no print job is active, camera name will be returned instead."
+
+    WebrtcRecordingFileNameResponse:
+      name: WebrtcRecordingFileNameResponse
+      summary: "File name of active print job, or camera name/display if no job is active"
+      payload:
+        x-parser-schema-id: WebrtcRecordingFileNameResponse
+        properties:
+          file_name:
+            type: string
+          ts:
+            type: integer
+            format: int64
+        required:
+          - file_name
+          - ts
+
   parameters:
     pi_id:
       description: The ID of the PrintNanny Pi/device
       schema:
         type: string
       location: "$message.header#/pi_id"
+
   schemas:
     NetworkInterfaceAddress:
       name: NetworkInterfaceAddress

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -155,6 +155,9 @@ pub use self::settings_file_revert_request::*;
 pub mod settings_file_revert_reply;
 pub use self::settings_file_revert_reply::*;
 
+pub mod webrtc_recording_file_name_response;
+pub use self::webrtc_recording_file_name_response::*;
+
 pub mod webrtc_recording;
 pub use self::webrtc_recording::*;
 

--- a/clients/rust/src/webrtc_recording_file_name_response.rs
+++ b/clients/rust/src/webrtc_recording_file_name_response.rs
@@ -1,0 +1,17 @@
+// WebrtcRecordingFileNameResponse represents a WebrtcRecordingFileNameResponse model.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct WebrtcRecordingFileNameResponse {
+    #[serde(rename="file_name")]
+    pub file_name: String,
+    #[serde(rename="ts")]
+    pub ts: String,
+}
+
+impl WebrtcRecordingFileNameResponse {
+    pub fn new(file_name: String, ts: String) -> WebrtcRecordingFileNameResponse {
+        WebrtcRecordingFileNameResponse {
+            file_name,
+            ts,
+        }
+    }
+}

--- a/clients/typescript/src/WebrtcRecordingFileNameResponse.ts
+++ b/clients/typescript/src/WebrtcRecordingFileNameResponse.ts
@@ -1,0 +1,5 @@
+
+export interface WebrtcRecordingFileNameResponse {
+  file_name: string;
+  ts: string;
+}

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -49,5 +49,6 @@ export * from "./SettingsFileApplyRequest";
 export * from "./SettingsFileApplyReply";
 export * from "./SettingsFileRevertRequest";
 export * from "./SettingsFileRevertReply";
+export * from "./WebrtcRecordingFileNameResponse";
 export * from "./WebrtcRecording";
 export * from "./WebrtcRecordingMedia";


### PR DESCRIPTION
Handler for these messages will get the current active print job file name, or camera name/display label if no job is active. 

ref: https://github.com/bitsy-ai/printnanny-os/issues/198